### PR TITLE
Fixed bug when restricting DHCP classes accidentally ignoring declare…

### DIFF
--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -847,7 +847,7 @@ EOPP;
 			// set pool MAC limitations
 			if ($poolconf['denyunknown'] == "class") {
 				$dhcpdconf .= "		allow members of \"s_{$dhcpif}\";\n";
-				$dhcpdconf .= "		$deny_action known-clients;\n";
+ 			//	$dhcpdconf .= "		$deny_action known-clients;\n";        // in combination with above and below options, this will disable all entries WITHOUT FIXED IPs!
 				$dhcpdconf .= "		$deny_action unknown-clients;\n";
 			} else if ($poolconf['denyunknown'] == "disabled") {
 				// add nothing to $dhcpdconf; condition added to prevent next condition applying if ever engine changes such that: isset("disabled") == true


### PR DESCRIPTION
Fixed bug when restricting DHCP classes (i.e. when ``$poolconf['denyunknown']=="class"``) accidentally ignoring declared hosts that are not explicitly assigned fixed IPs.

- [X ] Redmine Issue: https://redmine.pfsense.org/issues/4584
- [X ] Ready for review